### PR TITLE
Fixed broken delegates

### DIFF
--- a/MonoLibUsb/CallbackDelegates.cs
+++ b/MonoLibUsb/CallbackDelegates.cs
@@ -9,7 +9,7 @@ namespace MonoLibUsb
     /// </summary>
     /// <param name="transfer">The transfer previously allocated with <see cref="MonoUsbApi.AllocTransfer"/>.</param>
     [UnmanagedFunctionPointer(MonoUsbApi.CC)]
-    public delegate void MonoUsbTransferDelegate(MonoUsbTransfer transfer);
+    public delegate void MonoUsbTransferDelegate(IntPtr transfer);
 
     /// <summary>
     /// Callback delegate, invoked when a new file descriptor should be added to the set of file descriptors monitored for events. 

--- a/MonoLibUsb/MonoLibUsbApi.cs
+++ b/MonoLibUsb/MonoLibUsbApi.cs
@@ -44,8 +44,9 @@ namespace MonoLibUsb
         #region Private Members
 
         private static readonly MonoUsbTransferDelegate DefaultAsyncDelegate = DefaultAsyncCB;
-        private static void DefaultAsyncCB(MonoUsbTransfer transfer)
+        private static void DefaultAsyncCB(IntPtr transferI)
         {
+            MonoUsbTransfer transfer = new MonoUsbTransfer(transferI);
             ManualResetEvent completeEvent = GCHandle.FromIntPtr(transfer.PtrUserData).Target as ManualResetEvent;
             completeEvent.Set();
         }

--- a/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
+++ b/MonoLibUsb/Transfer/MonoUsbTransferContext.cs
@@ -223,8 +223,9 @@ namespace LibUsbDotNet.LudnMonoLibUsb.Internal
             }
         }
 
-        private static void TransferCallback(MonoUsbTransfer pTransfer)
+        private static void TransferCallback(IntPtr pTransferI)
         {
+            MonoUsbTransfer pTransfer = new MonoUsbTransfer(pTransferI);
             ManualResetEvent completeEvent = GCHandle.FromIntPtr(pTransfer.PtrUserData).Target as ManualResetEvent;
             completeEvent.Set();
         }


### PR DESCRIPTION
The MonoUsbTransferDelegate doesn't actually get a MonoUsbTransfer
object, it just gets an IntPtr and the wrapper needs to be created
explicitly.

I'm guessing the old code just happened to work by pure luck on some ABIs.  :smiley: 